### PR TITLE
fix: Move to Windows Server 2019 LTSC

### DIFF
--- a/templates/quickstart-dotnetfx-ecs-cicd-new-cluster.template.yaml
+++ b/templates/quickstart-dotnetfx-ecs-cicd-new-cluster.template.yaml
@@ -71,7 +71,7 @@ Parameters:
   BuildServerAmiId:
     Type: String
     Description: Amazon Machine Image (AMI) ID or Amazon Systems Manager Parameter Store (SSM) parameter expression to retrieve the AMI ID of the build server. Must be compatible with the operating system version used by the Amazon ECS cluster.
-    Default: "{{ssm:/aws/service/ami-windows-latest/Windows_Server-2004-English-Core-ECS_Optimized/image_id}}"
+    Default: "{{ssm:/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized/image_id}}"
   BuildServerInstanceType:
     Type: String
     Description: Type of the EC2 instance on the build server. For more information, see https://aws.amazon.com/ec2/instance-types/[Amazon EC2 Instance Types^].

--- a/templates/quickstart-dotnetfx-ecs-cicd.template.yaml
+++ b/templates/quickstart-dotnetfx-ecs-cicd.template.yaml
@@ -59,7 +59,7 @@ Parameters:
   BuildServerAmiId:
     Type: String
     Description: AMI ID or SSM Parameter expression to use to retrieve the AMI ID for the build server. Must be compatible with operating system version used by ECS cluster.
-    Default: "{{ssm:/aws/service/ami-windows-latest/Windows_Server-2004-English-Core-ECS_Optimized/image_id}}"
+    Default: "{{ssm:/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized/image_id}}"
   BuildServerInstanceType:
     Type: String
     Description: Type of the EC2 instance on the build server. For more information, see https://aws.amazon.com/ec2/instance-types/[Amazon EC2 Instance Types^].


### PR DESCRIPTION
- Windows Server version 2004 reached the end of servicing on December 14, 2021

*Issue #, if available:*
Fixes #15 

*Description of changes:*
Updated SSM parameter name to use the Windows Server 2019 Core LTSC param

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
